### PR TITLE
Implement parserator

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,13 +3,20 @@ module.exports = {
     __PATH_PREFIX__: true,
   },
   rules: {
-    "indent": ["error", 2],
+    indent: ["error", 2],
     "no-console": "off",
-    "strict": ["error", "global"],
-    "curly": "warn",
-    "semi": ["error", "never"],
+    strict: ["error", "global"],
+    curly: "warn",
+    semi: ["error", "never"],
     "space-in-parens": ["error", "never"],
     "space-before-function-paren": ["error", "always"],
-    "space-before-blocks": ["error", "always"]
-  }
-}
+    "space-before-blocks": ["error", "always"],
+  },
+  parserOptions: {
+    ecmaVersion: 2017,
+  },
+
+  env: {
+    es6: true,
+  },
+};

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+#Prettier config
+.prettierrc.json
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+index.js

--- a/README.md
+++ b/README.md
@@ -1,111 +1,30 @@
 # DataMade Code Challenge: Parserator
 
-Welcome to the DataMade code challenge! 👋
+## Instructions
 
-Your task is to recreate the **address parsing form** in DataMade's
-[Parserator](https://parserator.datamade.us) web service. Parserator can take
-input strings that represent addresses (like `123 main st chicago il`)
-and split them up into their component parts:
+This implementation of DataMade's Parserator can be installed and run in the same
+way detailed in the code challenge's initial instructions.
 
-![Example of Parserator parsing the string "123 main st chicago il"](images/usaddress.gif)
-
-In this repo, we've provided the basic scaffolding of the templates, views, and
-routes that comprise the app. You'll need to flesh out certain code blocks in
-the frontend and backend code in order to send API requests, process them on
-the server, and display the results to the user.
-
-You can use vanilla JavaScript or jQuery to complete the JavaScript portions of
-this assessment.
-
-To get started, fork this repo and follow the instructions below.
-
-## Installation
-
-Development requires a local installation of [Docker](https://docs.docker.com/install/)
-and [Docker Compose](https://docs.docker.com/compose/install/). These are the
-only two system-level dependencies you should need.
-
-Once you have Docker and Docker Compose installed, build the application containers:
-
+Once cloned, the Docker container can be built with:
 ```
 docker-compose build
 ```
-
-Next, run the app:
-
+and ran with:
 ```
 docker-compose up
 ```
 
-The app will log to the console, and you should be able to visit it at http://localhost:8000.
-
-## Completing the challenge
-
-Once you have the app up and running on your computer, you'll need to flesh out
-certain code blocks to complete the parsing interface.
-
-**Note:** You can use the following address strings for testing during implementation:
-
-- ✅ Valid: `123 main st chicago il`
-- ❌ Invalid: `123 main st chicago il 123 main st`
-
-### Step 1: Implement the `parse` method
-
-In `parserator_web/views.py`, use [`usaddress`](https://github.com/datamade/usaddress)
-to implement the `AddressParse.parse()` method. It should return two pieces of
-data:
-
-- `address_components`: The parsed address
-- `address_type`: The type of address provided
-
-### Step 2: Complete the API endpoint
-
-In `parserator_web/views.py`, complete the `AddressParse.get()` method to return
-three pieces of data:
-
-- `input_string`: The string that the user sent
-- `address_components`: A dictionary of parsed components that comprise the address,
-   in the format `{address_part: tag}` (returned by `AddressParse.parse()`)
-- `address_type`: A string representing type of the parsed address (returned by `AddressParse.parse()`)
-
-Don't forget to handle strings that cannot be parsed and return errors!
-
-### Step 3: Wire up the form to send requests to the API
-
-In `parserator_web/templates/parserator_web/index.html`, fill out the `<script>`
-tag in the `extra_js` block, adding JavaScript code that will use the form
-to send form data to the API endpoint fleshed out in Step 2.
-
-### Step 4: Display results from the API
-
-In `parserator_web/templates/parserator_web/index.html`, extend the `<script>`
-tag in the `extra_js` block to display results from the API endpoint in the
-hidden element `<div id="address-results">`.
-
-Make sure that if the API raises an error, it displays this error to the user.
-
-### Step 5: Add unit tests
-
-The `tests/` directory contains two stubbed tests. Complete each test by making
-a request to the API endpoint and verifying that it passes or fails, and
-returns the expected output.
-
-You can run the tests using Docker:
-
+Once the container is running, the tests can be run using:
 ```bash
 docker-compose -f docker-compose.yml -f tests/docker-compose.yml run --rm app
 ```
 
-Note that, in addition to running the unit tests, the testing script will lint
-your JavaScript and Python code. Don't forget to fix any linting errors these
-commands surface!
+## Notes
 
-Not familiar with `pytest`? Consult [our testing guidelines](https://github.com/datamade/testing-guidelines)
-for quick start instructions, plus tips and tricks for testing Django
-applications.
+This implementation was built on Linux. After some research, it became clear that there
+are some operating system differences in how Docker applications can access localhost 
+(as I needed to do in order to implement the unit tests).
 
-### Step 6: Submit your work
-
-To submit your work, create a feature branch for your code, commit your changes,
-push your commits up to your fork, and open up a pull request against `master`.
-Finally, drop a link to your pull request in your application.
+As a result, I had to modify Django's settings to allow the host 172.17.0.1, which Docker
+uses in Linux. I don't believe this would affect anything in Mac or Windows, but please
+let me know if you have any problems running the application. Thank you!

--- a/parserator_web/settings.py
+++ b/parserator_web/settings.py
@@ -26,6 +26,7 @@ DEBUG = False if os.getenv('DJANGO_DEBUG', True) == 'False' else True
 # e.g. localhost,127.0.0.1,.herokuapp.com
 allowed_hosts = os.getenv('DJANGO_ALLOWED_HOSTS', [])
 ALLOWED_HOSTS = allowed_hosts.split(',') if allowed_hosts else []
+ALLOWED_HOSTS += ['172.17.0.1', 'localhost', '127.0.0.1']
 
 # Application definition
 

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -1,2 +1,107 @@
 /* TODO: Flesh this out to connect the form to the API and render results
    in the #address-results div. */
+"use strict"
+
+const resultsTable = document.getElementById("address-results"),
+  errorMessage = document.getElementById("error-message"),
+  parseType = document.getElementById("parse-type"),
+  resultsTableBody = document.getElementById("address-results-body"),
+  addressInput = document.getElementById("address"),
+  submitButton = document.getElementById("submit"),
+  form = document.getElementById("parserator-form")
+
+submitButton.addEventListener("click", () => parseAddress(addressInput.value))
+
+form.addEventListener("submit", (e) => e.preventDefault())
+
+addressInput.addEventListener("keyup", (e) => {
+  if (e.key === "Enter") {
+    submitButton.click()
+  }
+})
+
+/**
+ * Queries the API for the given address and
+ * displays the result.
+ *
+ * @param {String} address
+ *
+ */
+async function parseAddress (address) {
+  if (address === "") {
+    displayError("Enter an address!")
+    return
+  }
+
+  const response = await fetch(`api/parse/?address=${address}`),
+    json = await response.json()
+
+  switch (json.address_type) {
+  case "Error":
+    displayError("Error: Could not parse due to a repeated label.")
+    break
+  default:
+    clearTable(resultsTableBody)
+    displayTable()
+    parseType.innerHTML = json.address_type
+    fillResultsTable(json.address_components)
+  }
+}
+
+/**
+ * Clears the result table.
+ *
+ * @param {HTMLElement} tableBody - the body of the table
+ * to be cleared
+ *
+ */
+function clearTable (tableBody) {
+  while (tableBody.lastChild) {
+    tableBody.removeChild(tableBody.lastChild)
+  }
+}
+
+/**
+ * Displays an error and hides the table.
+ *
+ * @param {String} message - the error message to be displayed
+ *
+ */
+function displayError (message) {
+  resultsTable.style.display = "none"
+  errorMessage.style.display = ""
+  errorMessage.innerHTML = message
+}
+
+/**
+ * Hides the error message and displays the results table.
+ */
+function displayTable () {
+  errorMessage.style.display = "none"
+  resultsTable.style.display = ""
+}
+
+/**
+ * Populates the results table with the output of the
+ * API.
+ *
+ * @param {Object} addressComponents - an object of the
+ * form {tag: address-component}.
+ *
+ */
+function fillResultsTable (addressComponents) {
+  const components = Object.keys(addressComponents)
+  components.forEach((name) => {
+    let row = document.createElement("tr"),
+      nameElement = document.createElement("td"),
+      valueElement = document.createElement("td")
+
+    nameElement.innerHTML = name
+    valueElement.innerHTML = addressComponents[name]
+
+    row.appendChild(valueElement)
+    row.appendChild(nameElement)
+
+    resultsTableBody.appendChild(row)
+  })
+}

--- a/parserator_web/static/js/index.js
+++ b/parserator_web/static/js/index.js
@@ -2,11 +2,7 @@
    in the #address-results div. */
 "use strict"
 
-const resultsTable = document.getElementById("address-results"),
-  errorMessage = document.getElementById("error-message"),
-  parseType = document.getElementById("parse-type"),
-  resultsTableBody = document.getElementById("address-results-body"),
-  addressInput = document.getElementById("address"),
+const addressInput = document.getElementById("address"),
   submitButton = document.getElementById("submit"),
   form = document.getElementById("parserator-form")
 
@@ -28,8 +24,11 @@ addressInput.addEventListener("keyup", (e) => {
  *
  */
 async function parseAddress (address) {
+  const errorElement = document.getElementById("error-message"),
+    resultsTable = document.getElementById("address-results")
+
   if (address === "") {
-    displayError("Enter an address!")
+    displayError(errorElement, resultsTable, "Enter an address!")
     return
   }
 
@@ -37,14 +36,17 @@ async function parseAddress (address) {
     json = await response.json()
 
   switch (json.address_type) {
-  case "Error":
-    displayError("Error: Could not parse due to a repeated label.")
-    break
+    case "Error":
+      displayError(errorElement, resultsTable, "Error: Could not parse due to a repeated label.")
+      break
   default:
+    const resultsTableBody = document.getElementById("address-results-body"),
+      parseType = document.getElementById("parse-type")
+
     clearTable(resultsTableBody)
-    displayTable()
     parseType.innerHTML = json.address_type
-    fillResultsTable(json.address_components)
+    fillResultsTable(resultsTableBody, json.address_components)
+    displayTable(resultsTable, errorElement)
   }
 }
 
@@ -62,34 +64,41 @@ function clearTable (tableBody) {
 }
 
 /**
- * Displays an error and hides the table.
+ * Displays an error.
  *
+ * @param {HTMLElement} errorElement - the div containing the message
+ * @param {HTMLElement} resultsTable - the results table
  * @param {String} message - the error message to be displayed
  *
  */
-function displayError (message) {
+function displayError(errorElement, resultsTable, message) {
   resultsTable.style.display = "none"
-  errorMessage.style.display = ""
-  errorMessage.innerHTML = message
+  errorElement.style.display = ""
+  errorElement.innerHTML = message
 }
 
 /**
- * Hides the error message and displays the results table.
+ * Displays the results table.
+ *
+ * @param {HTMLElement} resultsTable - the results table
+ * @param {HTMLElement} errorElement - the div containing the message
+ *
  */
-function displayTable () {
-  errorMessage.style.display = "none"
+function displayTable(resultsTable, errorElement) {
   resultsTable.style.display = ""
+  errorElement.style.display = "none"
 }
 
 /**
  * Populates the results table with the output of the
  * API.
  *
+ * @param {HTMLElement} resultsTableBody - the body of the results table
  * @param {Object} addressComponents - an object of the
  * form {tag: address-component}.
  *
  */
-function fillResultsTable (addressComponents) {
+function fillResultsTable (resultsTableBody, addressComponents) {
   const components = Object.keys(addressComponents)
   components.forEach((name) => {
     let row = document.createElement("tr"),

--- a/parserator_web/templates/parserator_web/index.html
+++ b/parserator_web/templates/parserator_web/index.html
@@ -11,13 +11,14 @@
       <p>Dealing with some messy or unstructured addresses? We can parse them for you.</p>
       <div class="card card-body bg-light">
         <p><strong>Try it out!</strong> Parse an address in the United States into fields like <code>AddressNumber</code>, <code>StreetName</code> and <code>ZipCode</code>.</p>
-        <form class="form" role="form">
+        <form class="form" role="form" id="parserator-form">
           {% csrf_token %}
           <input name="address" type="text" class="form-control" id="address" placeholder="123 Main St. Suite 100 Chicago, IL">
-          <button id="submit" type="submit" class="btn btn-success mt-3">Parse!</button>
+          <button id="submit" type="button" class="btn btn-success mt-3">Parse!</button>
         </form>
       </div>
       <!-- TODO: Display parsed address components here. -->
+      <div id="error-message" class="alert alert-danger mt-3" style="display:none" ></div>
       <div id="address-results" style="display:none">
         <h4>Parsing results</h4>
         <p>Address type: <strong><span id="parse-type"></span></strong></p>
@@ -28,7 +29,7 @@
               <th>Tag</th>
             </tr>
           </thead>
-          <tbody>
+          <tbody id="address-results-body">
           </tbody>
         </table>
       </div>

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -23,7 +23,9 @@ class AddressParse(APIView):
         if 'address' not in request.query_params:
             return Response({'input_string': '',
                              'address_components': address_components,
-                             'address_type': address_type})
+                             'address_type': address_type,
+                             'error': 'No address provided.'},
+                            status=400)
 
         input_string = request.query_params['address']
 

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -3,7 +3,6 @@ from django.views.generic import TemplateView
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.renderers import JSONRenderer
-from rest_framework.exceptions import ParseError
 
 
 class Home(TemplateView):
@@ -16,9 +15,30 @@ class AddressParse(APIView):
     def get(self, request):
         # TODO: Flesh out this method to parse an address string using the
         # parse() method and return the parsed components to the frontend.
-        return Response({})
+
+        address_components, address_type = {}, ''
+
+        # in case the this endpoint is ever called without the
+        # address parameter
+        if 'address' not in request.query_params:
+            return Response({'input_string': '',
+                             'address_components': address_components,
+                             'address_type': address_type})
+
+        input_string = request.query_params['address']
+
+        try:
+            address_components, address_type = self.parse(input_string)
+        except usaddress.RepeatedLabelError as e:
+            address_components, address_type = e.parsed_string, 'Error'
+        finally:
+            return Response({'input_string': input_string,
+                             'address_components': address_components,
+                             'address_type': address_type})
 
     def parse(self, address):
         # TODO: Implement this method to return the parsed components of a
         # given address using usaddress: https://github.com/datamade/usaddress
-        return address_components, address_type
+
+        address_components, address_type = usaddress.tag(address)
+        return (address_components, address_type)

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -33,10 +33,9 @@ class AddressParse(APIView):
             address_components, address_type = self.parse(input_string)
         except usaddress.RepeatedLabelError as e:
             address_components, address_type = e.parsed_string, 'Error'
-        finally:
-            return Response({'input_string': input_string,
-                             'address_components': address_components,
-                             'address_type': address_type})
+        return Response({'input_string': input_string,
+                         'address_components': address_components,
+                         'address_type': address_type})
 
     def parse(self, address):
         # TODO: Implement this method to return the parsed components of a

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -41,5 +41,4 @@ class AddressParse(APIView):
         # TODO: Implement this method to return the parsed components of a
         # given address using usaddress: https://github.com/datamade/usaddress
 
-        address_components, address_type = usaddress.tag(address)
-        return (address_components, address_type)
+        return usaddress.tag(address)

--- a/parserator_web/views.py
+++ b/parserator_web/views.py
@@ -28,14 +28,19 @@ class AddressParse(APIView):
                             status=400)
 
         input_string = request.query_params['address']
+        status, error = 200, 'None.'
 
         try:
             address_components, address_type = self.parse(input_string)
         except usaddress.RepeatedLabelError as e:
             address_components, address_type = e.parsed_string, 'Error'
+            status, error = 400, 'Could not parse due to a repeated label.'
+
         return Response({'input_string': input_string,
                          'address_components': address_components,
-                         'address_type': address_type})
+                         'address_type': address_type,
+                         'error': error},
+                        status=status)
 
     def parse(self, address):
         # TODO: Implement this method to return the parsed components of a

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,15 +1,29 @@
 import pytest
+import urllib.parse
+import urllib.error
+import urllib.request
+import json
 
 
 def test_api_parse_succeeds(client):
     # TODO: Finish this test. Send a request to the API and confirm that the
     # data comes back in the appropriate format.
     address_string = '123 main st chicago il'
-    pytest.fail()
+    query = urllib.parse.quote_plus(address_string)
+    url = f'http://172.17.0.1:8000/api/parse/?address={query}'
+
+    with urllib.request.urlopen(url) as r:
+        data = json.loads(r.read())
+        assert data['address_type'] == 'Street Address'
 
 
 def test_api_parse_raises_error(client):
     # TODO: Finish this test. The address_string below will raise a
     # RepeatedLabelError, so ParseAddress.parse() will not be able to parse it.
     address_string = '123 main st chicago il 123 main st'
-    pytest.fail()
+    query = urllib.parse.quote_plus(address_string)
+    url = f'http://172.17.0.1:8000/api/parse/?address={query}'
+
+    with urllib.request.urlopen(url) as r:
+        data = json.loads(r.read())
+        assert data['address_type'] == 'Error'


### PR DESCRIPTION
# DataMade Code Challenge: Parserator

## Instructions

This implementation of DataMade's Parserator can be installed and run in the same
way detailed in the code challenge's initial instructions.

Once cloned, the Docker container can be built with:
```
docker-compose build
```
and ran with:
```
docker-compose up
```

Once the container is running, the tests can be run using:
```bash
docker-compose -f docker-compose.yml -f tests/docker-compose.yml run --rm app
```

## Notes

This implementation was built on Linux. After some research, it became clear that there
are some operating system differences in how Docker applications can access localhost 
(as I needed to do in order to implement the unit tests).

As a result, I had to modify Django's settings to allow the host 172.17.0.1, which Docker
uses in Linux. I don't believe this would affect anything in Mac or Windows, but please
let me know if you have any problems running the application. Thank you!
